### PR TITLE
fix: discard more bad source map positions

### DIFF
--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -8,6 +8,10 @@ var pathutils = require('./pathutils'),
     libCoverage = require('istanbul-lib-coverage'),
     MappedCoverage = require('./mapped').MappedCoverage;
 
+function isInvalidPosition (pos) {
+    return !pos || !pos.line || !pos.column || pos.line < 0 || pos.column < 0;
+}
+
 /**
  * determines the original position for a given location
  * @param  {SourceMapConsumer} sourceMap the source map
@@ -15,6 +19,14 @@ var pathutils = require('./pathutils'),
  * @returns {Object} the remapped location Object
  */
 function getMapping(sourceMap, location, origFile) {
+ 
+    if (!location) {
+        return null;
+    }
+
+    if (isInvalidPosition(location.start) || isInvalidPosition(location.end)) {
+        return null;
+    }
 
     var start = sourceMap.originalPositionFor(location.start),
         end = sourceMap.originalPositionFor(location.end);


### PR DESCRIPTION
Restore code that was introduced in nyc 6.5.0 to handle bad source map locations. This fix was originally introduced into nyc's lib/source-map-cache.js, but when nyc transitioned to using istanbul-lib-source-maps this fix went astray.

see original PR: https://github.com/istanbuljs/nyc/pull/255
