### PR TITLE
Fix broken mapped coverage map

### DIFF
--- a/lib/mapped.js
+++ b/lib/mapped.js
@@ -31,8 +31,8 @@ MappedCoverage.prototype.addStatement = function (loc, hits) {
         index = meta.seen[key];
 
     if (!index) {
-        meta.last.s += 1;
         index = meta.last.s;
+        meta.last.s += 1;
         meta.seen[key] = index;
         this.statementMap[index] = this.cloneLocation(loc);
     }
@@ -47,8 +47,8 @@ MappedCoverage.prototype.addFunction = function (name, decl, loc, hits) {
         index = meta.seen[key];
 
     if (!index) {
-        meta.last.f += 1;
         index = meta.last.f;
+        meta.last.f += 1;
         meta.seen[key] = index;
         name = name || '(unknown_' + index + ')';
         this.fnMap[index] = {
@@ -76,8 +76,8 @@ MappedCoverage.prototype.addBranch = function (type, loc, branchLocations, hits)
     key = key.join(':');
     index = meta.seen[key];
     if (!index) {
-        meta.last.b += 1;
         index = meta.last.b;
+        meta.last.b += 1;
         meta.seen[key] = index;
         this.branchMap[index] = {
             loc: loc,
@@ -118,4 +118,3 @@ MappedCoverage.prototype.cloneLocation = function (loc) {
 module.exports = {
     MappedCoverage: MappedCoverage
 };
-

--- a/lib/mapped.js
+++ b/lib/mapped.js
@@ -30,7 +30,7 @@ MappedCoverage.prototype.addStatement = function (loc, hits) {
         meta = this.meta,
         index = meta.seen[key];
 
-    if (!index) {
+    if (index === undefined) {
         index = meta.last.s;
         meta.last.s += 1;
         meta.seen[key] = index;
@@ -46,7 +46,7 @@ MappedCoverage.prototype.addFunction = function (name, decl, loc, hits) {
         meta = this.meta,
         index = meta.seen[key];
 
-    if (!index) {
+    if (index === undefined) {
         index = meta.last.f;
         meta.last.f += 1;
         meta.seen[key] = index;
@@ -75,7 +75,7 @@ MappedCoverage.prototype.addBranch = function (type, loc, branchLocations, hits)
 
     key = key.join(':');
     index = meta.seen[key];
-    if (!index) {
+    if (index === undefined) {
         index = meta.last.b;
         meta.last.b += 1;
         meta.seen[key] = index;

--- a/test/mapped.test.js
+++ b/test/mapped.test.js
@@ -27,7 +27,7 @@ describe('mapped coverage', function () {
             sc;
 
         index = mc.addStatement(loc(1, 0, 1, 100), 1);
-        assert.ok(index === 0);
+        assert.strictEqual(index, 0);
         assert.deepEqual(mc.statementMap[index], loc(1, 0, 1, 100));
 
         index2 = mc.addStatement(loc(1, 0, 1, 100), 1);
@@ -38,7 +38,7 @@ describe('mapped coverage', function () {
         mc.s[index] = 20;
 
         index = mc.addFunction('foo', loc(1, 0, 1, 20), loc(1, 0, 1, 100), 0);
-        assert.ok(index === 0);
+        assert.strictEqual(index, 0);
         assert.deepEqual(mc.fnMap[index].decl, loc(1, 0, 1, 20));
         assert.deepEqual(mc.fnMap[index].loc, loc(1, 0, 1, 100));
 
@@ -51,7 +51,7 @@ describe('mapped coverage', function () {
         assert.equal(mc.fnMap[index].name,'(unknown_' + index + ')');
 
         index = mc.addBranch('if', loc(1, 15, 1, 20), [loc(1, 15, 1, 20), loc(1, 21, 1, 40)], [1,0]);
-        assert.ok(index === 0);
+        assert.strictEqual(index, 0);
         assert.deepEqual(mc.branchMap[index].loc, loc(1, 15, 1, 20));
         assert.deepEqual(mc.branchMap[index].locations[0], loc(1, 15, 1, 20));
         assert.deepEqual(mc.branchMap[index].locations[1], loc(1, 21, 1, 40));

--- a/test/mapped.test.js
+++ b/test/mapped.test.js
@@ -27,7 +27,7 @@ describe('mapped coverage', function () {
             sc;
 
         index = mc.addStatement(loc(1, 0, 1, 100), 1);
-        assert.ok(index);
+        assert.ok(index === 0);
         assert.deepEqual(mc.statementMap[index], loc(1, 0, 1, 100));
 
         index2 = mc.addStatement(loc(1, 0, 1, 100), 1);
@@ -38,7 +38,7 @@ describe('mapped coverage', function () {
         mc.s[index] = 20;
 
         index = mc.addFunction('foo', loc(1, 0, 1, 20), loc(1, 0, 1, 100), 0);
-        assert.ok(index);
+        assert.ok(index === 0);
         assert.deepEqual(mc.fnMap[index].decl, loc(1, 0, 1, 20));
         assert.deepEqual(mc.fnMap[index].loc, loc(1, 0, 1, 100));
 
@@ -51,7 +51,7 @@ describe('mapped coverage', function () {
         assert.equal(mc.fnMap[index].name,'(unknown_' + index + ')');
 
         index = mc.addBranch('if', loc(1, 15, 1, 20), [loc(1, 15, 1, 20), loc(1, 21, 1, 40)], [1,0]);
-        assert.ok(index);
+        assert.ok(index === 0);
         assert.deepEqual(mc.branchMap[index].loc, loc(1, 15, 1, 20));
         assert.deepEqual(mc.branchMap[index].locations[0], loc(1, 15, 1, 20));
         assert.deepEqual(mc.branchMap[index].locations[1], loc(1, 21, 1, 40));

--- a/test/transformer.test.js
+++ b/test/transformer.test.js
@@ -16,7 +16,7 @@ function createData() {
     var coverageData = {
         "path": "/path/to/file.js",
         "statementMap": {
-            "1": {
+            "0": {
                 "start": {
                     "line": 2,
                     "column": 0
@@ -26,7 +26,7 @@ function createData() {
                     "column": 29
                 }
             },
-            "2": {
+            "1": {
                 "start": {
                     "line": 3,
                     "column": 0
@@ -40,9 +40,9 @@ function createData() {
         "fnMap": {},
         "branchMap": {},
         "s": {
+            "0": 0,
             "1": 0,
-            "2": 0,
-            "3": 0
+            "2": 0
         },
         "f": {},
         "b": {}
@@ -67,8 +67,8 @@ describe('transformer', function () {
         }).transform(coverageMap);
 
         assert.deepEqual(mapped.data[coverageData.path].statementMap, {
-            '1': { start: { line: 1, column: 13 }, end: { line: 1, column: 34 } },
-            '2': { start: { line: 2, column: 13 }, end: { line: 2, column: 52 } }
+            '0': { start: { line: 1, column: 13 }, end: { line: 1, column: 34 } },
+            '1': { start: { line: 2, column: 13 }, end: { line: 2, column: 52 } }
         });
     });
 });


### PR DESCRIPTION
Closes https://github.com/istanbuljs/nyc/issues/400, closes https://github.com/istanbuljs/istanbul-lib-instrument/issues/25.

@bcoe sorry this slipped past me! The bug was only visible when you run coverage on both source-mapped and non-source-mapped files and then it tried to merge the two.
- [x] update tests
